### PR TITLE
修复列表在拖拽过后,scrollToView(xxx, true)无法正确播放滚动动画的问题;

### DIFF
--- a/FairyGUI-egret/src/ScrollPane.ts
+++ b/FairyGUI-egret/src/ScrollPane.ts
@@ -1078,6 +1078,9 @@ module fairygui {
             if (!this.isDragged || !this._touchEffect || this._inertiaDisabled || this._owner.displayObject.stage == null)
                 return;
 
+            // touch事件不一定都是以tap结束,拖拽的结束动作是touchEnd,这时需要正确处理isDragged标记位.否则在播放滚动动画时会因为处于拖拽状态而使滚动动画失效
+            this.isDragged = false;
+
             var time: number = (egret.getTimer() - this._time2) / 1000;
             if (time == 0)
                 time = 0.001;


### PR DESCRIPTION
BUG 复现方式:
1.调用list.scrollToView(xxx, true)
2.手动拖拽列表项
3.再次调用list.scrollToView(xxx, true)

第三步时,列表会直接跳转至指定项,而不播放滚动的缓动动画.