### PR TITLE
fix bug: GTextInput can't set text manually

### DIFF
--- a/FairyGUI-egret/src/GTextInput.ts
+++ b/FairyGUI-egret/src/GTextInput.ts
@@ -100,6 +100,7 @@ module fairygui {
         protected updateTextFieldText(): void {
             if (!this._text && this._promptText) {
                 this._textField.displayAsPassword = false;
+                this._textField.text = this._text;
                 this._textField.textFlow = (new egret.HtmlTextParser).parser(ToolSet.parseUBB(this._promptText));
             }
             else {


### PR DESCRIPTION
``GTextInput::updateTextFieldText()`` override ``GTextField:…  …
…:updateFiledText()``, if we call ``set Text`` function,the value of ``this._textField.text`` won't change